### PR TITLE
Inherit from Capybara::Selenium::Driver

### DIFF
--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -1,10 +1,9 @@
 module Appium::Capybara
-  class Appium::Capybara::Driver < Capybara::Driver::Base
-    DEFAULT_OPTIONS = {
-    }
+  # methods in this class either override selenium driver methods
+  # or they're new and specific to appium.
+  class Appium::Capybara::Driver < Capybara::Selenium::Driver
 
-    attr_reader :app, :options
-
+    # override
     def browser
       unless @browser
         @browser = Appium::Driver.new @options
@@ -14,35 +13,60 @@ module Appium::Capybara
       @browser
     end
 
-    def initialize(app, options = {})
-      @app = app
-      @options = DEFAULT_OPTIONS.merge(options)
-    end
-
-    def browser_initialized?
-      !@browser.nil?
-    end
-
-    def reset!
-      browser.driver.reset
-    end
-
-    def wait?
-      false
-    end
-
+    # override
     def find_xpath(selector)
       browser.find_elements(:xpath, selector).map { |node| Appium::Capybara::Node.new(self, node) }
     end
 
+    # override
     def find_css(selector)
       browser.find_elements(:css, selector).map { |node| Appium::Capybara::Node.new(self, node) }
     end
 
+    # override
+    def reset!
+      # invoking the browser method after the browser has closed will cause it to relaunch
+      # use @browser to avoid the relaunch.
+      @browser.driver.reset
+    end
+
+    # new
+    def browser_initialized?
+      !browser.nil?
+    end
+
+    # new
+    def dismiss_alert
+      browser.alert_dismiss
+    end
+
+    # new
+    def accept_alert
+      browser.alert_accept
+    end
+
+    # new
+    def scroll_up
+      browser.driver.execute_script("mobile: scroll", direction: "up")
+    end
+
+    # new
+    def scroll_down
+      browser.driver.execute_script("mobile: scroll", direction: "down")
+    end
+
+    # new
+    # Use :landscape or :portrait
+    def rotate(opts)
+      browser.driver.rotate opts
+    end
+
+    # new
     def find_custom(finder, locator)
       browser.find_elements(finder, locator).map { |node| Appium::Capybara::Node.new(self, node) }
     end
 
+    # override
     def quit
       @browser.driver_quit if @browser
     rescue Errno::ECONNREFUSED
@@ -51,35 +75,5 @@ module Appium::Capybara
       @browser = nil
     end
 
-    def current_url
-      raise NotImplementedError,
-        "Appium::Capybara::Driver does not support current_url because it does not apply to mobile applications"
-    end
-
-    def visit(path)
-      raise NotImplementedError,
-        "Appium::Capybara::Driver does not support visit(path) because it does not apply to mobile applications"
-    end
-
-    def dismiss_alert
-      browser.alert_dismiss
-    end
-
-    def accept_alert
-      browser.alert_accept
-    end
-
-    def scroll_up
-      browser.driver.execute_script("mobile: scroll", direction: "up")
-    end
-
-    def scroll_down
-      browser.driver.execute_script("mobile: scroll", direction: "down")
-    end
-
-    # Use :landscape or :portrait
-    def rotate(opts)
-      browser.driver.rotate opts
-    end
-  end
-end
+  end # Appium::Capybara::Driver < Capybara::Selenium::Driver
+end # Appium::Capybara


### PR DESCRIPTION
@sbonebrake I think the general approach for driver.rb is wrong. Instead we should start with `lib/capybara/selenium/driver.rb` and then only change what's necessary.
- appium supports web automation so in theory someone could use .visit and it'd work.
- this also fixes #6 which is caused from our driver diverging from the selenium driver
