### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ end
 Capybara.default_driver = :appium
 ```
 
+## Capybara server
+appium_capybara driver automatically starts a Rails server in `test` environment.
+
+By default Capybara starts this web server listening to localhost only and on a random port. It is advised
+to force Capybara to listen to all interface and listen to a specific port, and set this server address
+in your mobile application.
+
+```ruby
+Capybara.server_host = '0.0.0.0' # Listen to all interfaces
+Capybara.server_port = 56844     # Open port TCP 56844, change at your convenience
+```
+
 ## Publishing to rubygems
 
 Make sure to run `thor bump` or manually modify version.rb before publishing. RubyGems will not allow the same

--- a/appium_capybara.gemspec
+++ b/appium_capybara.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'appium_lib', '~> 4', '>= 4.1.0'
   s.add_runtime_dependency 'capybara', '~> 2.4', '>= 2.4.1'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 2.40'
 
   s.add_development_dependency 'appium_thor', '~> 0.0', '>= 0.0.7'
 

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -1,10 +1,9 @@
 module Appium::Capybara
-  class Appium::Capybara::Driver < Capybara::Driver::Base
-    DEFAULT_OPTIONS = {
-    }
+  # methods in this class either override selenium driver methods
+  # or they're new and specific to appium.
+  class Appium::Capybara::Driver < Capybara::Selenium::Driver
 
-    attr_reader :app, :options
-
+    # override
     def browser
       unless @browser
         @browser = Appium::Driver.new @options
@@ -14,35 +13,60 @@ module Appium::Capybara
       @browser
     end
 
-    def initialize(app, options = {})
-      @app = app
-      @options = DEFAULT_OPTIONS.merge(options)
-    end
-
-    def browser_initialized?
-      !@browser.nil?
-    end
-
-    def reset!
-      browser.driver.reset
-    end
-
-    def wait?
-      false
-    end
-
+    # override
     def find_xpath(selector)
       browser.find_elements(:xpath, selector).map { |node| Appium::Capybara::Node.new(self, node) }
     end
 
+    # override
     def find_css(selector)
       browser.find_elements(:css, selector).map { |node| Appium::Capybara::Node.new(self, node) }
     end
 
+    # override
+    def reset!
+      # invoking the browser method after the browser has closed will cause it to relaunch
+      # use @browser to avoid the relaunch.
+      @browser.driver.reset if @browser
+    end
+
+    # new
+    def browser_initialized?
+      !! @browser
+    end
+
+    # new
+    def dismiss_alert
+      browser.alert_dismiss
+    end
+
+    # new
+    def accept_alert
+      browser.alert_accept
+    end
+
+    # new
+    def scroll_up
+      browser.driver.execute_script("mobile: scroll", direction: "up")
+    end
+
+    # new
+    def scroll_down
+      browser.driver.execute_script("mobile: scroll", direction: "down")
+    end
+
+    # new
+    # Use :landscape or :portrait
+    def rotate(opts)
+      browser.driver.rotate opts
+    end
+
+    # new
     def find_custom(finder, locator)
       browser.find_elements(finder, locator).map { |node| Appium::Capybara::Node.new(self, node) }
     end
 
+    # override
     def quit
       @browser.driver_quit if @browser
     rescue Errno::ECONNREFUSED
@@ -51,25 +75,5 @@ module Appium::Capybara
       @browser = nil
     end
 
-    def dismiss_alert
-      browser.alert_dismiss
-    end
-
-    def accept_alert
-      browser.alert_accept
-    end
-
-    def scroll_up
-      browser.driver.execute_script("mobile: scroll", direction: "up")
-    end
-
-    def scroll_down
-      browser.driver.execute_script("mobile: scroll", direction: "down")
-    end
-
-    # Use :landscape or :portrait
-    def rotate(opts)
-      browser.driver.rotate opts
-    end
-  end
-end
+  end # Appium::Capybara::Driver < Capybara::Selenium::Driver
+end # Appium::Capybara

--- a/lib/appium_capybara/ext/session_ext.rb
+++ b/lib/appium_capybara/ext/session_ext.rb
@@ -4,7 +4,8 @@ module Capybara
       # Next line is a work around for issue https://github.com/jnicklas/capybara/issues/1237
       if @touched && driver.browser_initialized?
         driver.reset!
-        assert_no_selector(:xpath, "/html/body/*")
+        # Ugly hack to not run this assertion for Appium
+        assert_no_selector(:xpath, "/html/body/*") unless driver.instance_of? Appium::Capybara::Driver
         @touched = false
       end
       raise_server_error!

--- a/lib/appium_capybara/version.rb
+++ b/lib/appium_capybara/version.rb
@@ -1,6 +1,6 @@
 module Appium
   module Capybara
-    VERSION = '0.0.3' unless defined? ::Appium::Capybara::VERSION
-    DATE    = '2014-08-06' unless defined? ::Appium::Capybara::DATE
+    VERSION = '0.0.4' unless defined? ::Appium::Capybara::VERSION
+    DATE    = '2014-08-07' unless defined? ::Appium::Capybara::DATE
   end
 end

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,9 @@
+#### v0.0.4 2014-08-07
+
+- [16061f4](https://github.com/appium/appium_capybara/commit/16061f43ef4ac0796bc05f9d4af9e22e58d769e1) Release 0.0.4
+- [be07877](https://github.com/appium/appium_capybara/commit/be078778c265a6483c54290e87baff786312f495) Fixed crash that sometimes occurs in session.reset! and added better error messages for driver's visit and current_url methods
+
+
 #### v0.0.3 2014-08-06
 
 - [ee4a9bd](https://github.com/appium/appium_capybara/commit/ee4a9bdab696e5e516ee92d7a9db1e325940fcaf) Release 0.0.3


### PR DESCRIPTION
1- Added documentation about Capybara server port and interface, cause people will necessarily bump into this, given the fact that Capybara by default listen only 127.0.0.1 and an mobile app won't be able to access it.

2- Added dependency for selenium-webdriver - let me know if the version suits you

3- Fixed `reset!` to avoid "NoMethodError" and `browser_initialized?` to avoid starting a new driver
