### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ end
 Capybara.default_driver = :appium
 ```
 
+## Capybara server
+appium_capybara driver automatically starts a Rails server in `test` environment.
+
+By default Capybara starts this web server listening to localhost only and on a random port. It is advised
+to force Capybara to listen to all interface and listen to a specific port, and set this server address
+in your mobile application.
+
+```ruby
+Capybara.server_host = '0.0.0.0' # Listen to all interfaces
+Capybara.server_port = 56844     # Open port TCP 56844, change at your convenience
+```
+
 ## Publishing to rubygems
 
 Make sure to run `thor bump` or manually modify version.rb before publishing. RubyGems will not allow the same

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -27,12 +27,12 @@ module Appium::Capybara
     def reset!
       # invoking the browser method after the browser has closed will cause it to relaunch
       # use @browser to avoid the relaunch.
-      @browser.driver.reset
+      @browser.driver.reset if @browser
     end
 
     # new
     def browser_initialized?
-      !browser.nil?
+      !! @browser
     end
 
     # new


### PR DESCRIPTION
1- Added documentation about Capybara server port and interface, cause people will necessarily bump into this, given the fact that Capybara by default listen only 127.0.0.1 and an mobile app won't be able to access it.

2- Fixed reset! to avoid "NoMethodError" and browser_initialized? to avoid starting a new driver
