### PR TITLE
Make save_screenshot proxy commands to appium_lib screenshot command.

### DIFF
--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -64,6 +64,11 @@ module Appium::Capybara
       browser.driver.rotate opts
     end
 
+    # override
+    def save_screenshot(path)
+      browser.screenshot(path)
+    end
+
     # new
     def find_custom(finder, locator)
       browser.find_elements(finder, locator).map { |node| Appium::Capybara::Node.new(self, node) }


### PR DESCRIPTION
This makes the `save_screenshot` command work in capybara.
