### PR TITLE
Screenshot needs to accept an options hash.

### DIFF
--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -65,8 +65,9 @@ module Appium::Capybara
     end
 
     # override
-    def save_screenshot(path)
-      browser.screenshot(path)
+    # Capybara always passes an options param but appium_lib can't do anything with it.
+    def save_screenshot(path, options = {})
+      browser.screenshot path
     end
 
     # new


### PR DESCRIPTION
This is on me; should've paid more attention. Without this, you can call `page.driver.screenshot` but not `page.screenshot`.
