### PR TITLE
Allow to use different drivers in the same test suite

### DIFF
--- a/lib/appium_capybara/ext/session_ext.rb
+++ b/lib/appium_capybara/ext/session_ext.rb
@@ -1,8 +1,10 @@
 module Capybara
   class Session
     def reset!
-      # Next line is a work around for issue https://github.com/jnicklas/capybara/issues/1237
-      if @touched && driver.browser_initialized?
+      # Work around for issue https://github.com/jnicklas/capybara/issues/1237
+      browser_initialized = driver.respond_to?(:browser_initialized?) ? driver.browser_initialized? : true
+
+      if @touched && browser_initialized
         driver.reset!
         # Ugly hack to not run this assertion for Appium
         assert_no_selector(:xpath, "/html/body/*") unless driver.instance_of? Appium::Capybara::Driver


### PR DESCRIPTION
In my test suite I use different drivers, including appium_capybara.

I get this message for tests that use other drivers (selenium for example)

```
NoMethodError: undefined method `browser_initialized?' for #<Capybara::Selenium::Driver:0x007fdcf1773028>
appium_capybara/lib/appium_capybara/ext/session_ext.rb:5:in `reset!'
```

This pull request fix it
