### PR TITLE
Rename accept/dismiss modal methods.

### DIFF
--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -48,13 +48,15 @@ module Appium::Capybara
       !! @browser
     end
 
-    # new
-    def dismiss_alert
+    # override
+    # type and options are passed but can be ignored.
+    def dismiss_modal(type, options={}, &blk)
       appium_driver.alert_dismiss
     end
 
-    # new
-    def accept_alert
+    # override
+    # type and options are passed but can be ignored.
+    def accept_modal(type, options={}, &blk)
       appium_driver.alert_accept
     end
 


### PR DESCRIPTION
`Capybara::Session` has an `accept_alert` method, among others, that leverage the `accept_modal` and `dismiss_modal` methods on the driver. Right now those are missing so Capybara is falling back to the Selenium implementation, which calls `switch_to` and breaks. From the comments in the appium lib it seems that these methods were intended to replace the accept/dismiss modal methods instead of being new.
