### PR TITLE
Do not take screenshot if no driver is running. Auto-quit driver at_exit 

### DIFF
--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -22,6 +22,14 @@ module Appium::Capybara
         @appium_driver = Appium::Driver.new @options
         # browser is the standard selenium driver without any appium methods
         @browser = @appium_driver.start_driver
+
+        main = Process.pid
+        at_exit do
+          # Store the exit status of the test run since it goes away after calling the at_exit proc...
+          @exit_status = $!.status if $!.is_a?(SystemExit)
+          quit if Process.pid == main
+          exit @exit_status if @exit_status # Force exit with stored status
+        end
       end
       @browser
     end
@@ -79,7 +87,7 @@ module Appium::Capybara
     # override
     # Capybara always passes an options param but appium_lib can't do anything with it.
     def save_screenshot(path, options = {})
-      appium_driver.screenshot path
+      appium_driver.screenshot path if @appium_driver
     end
 
     # new


### PR DESCRIPTION
1) Take screenshots only if app is launched (prevent launching new appium_driver to take a screenshot)
2) Quit appium driver at_exit (same as for Capybara::Selenium::Driver)