### PR TITLE
Add custom tag in selector. This is for Element Finding Plugins.

### DIFF
--- a/lib/appium_capybara/ext/selector_ext.rb
+++ b/lib/appium_capybara/ext/selector_ext.rb
@@ -20,3 +20,6 @@ end
 Capybara.add_selector(:accessibility_id) do
   custom(:accessibility_id) { |locator| locator }
 end
+Capybara.add_selector(:custom) do
+  custom(:custom) { |locator| locator }
+end


### PR DESCRIPTION
From version 1.9.2, Appium supports the use of [Element Finding Plugins](https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/element-finding-plugins.md).
This pull requeset is for using this custom tag in SitePrism and Capybara.

### I have a question.
appium_capybara does not includes test codes.
And now, I only know element finding plugin, [Test.ai Classifier Plugin for Appium](https://github.com/testdotai/appium-classifier-plugin).

However, it is not good for adding Test.ai Classifier Plugin in example because anyone cannot execute example.
I just tried and checked to work well in my local, but the source code in example is not committed because of above.

Is it OK?

(In fact, the example apps is not suitable for Test.ai Classifier Plugin because there are no elements selected by Test.ai Classifier Plugin... I could check Test.ai Classifier Plugin  working well from appium's AI tag log .)