### PR TITLE
Fix lib for Capybara 3.19+

### DIFF
--- a/lib/appium_capybara/ext/selector_ext.rb
+++ b/lib/appium_capybara/ext/selector_ext.rb
@@ -1,5 +1,5 @@
 module Capybara
-  class Selector
+  class Selector::Definition
 
     def custom(f, &block)
       @format, @expression = f, block if block


### PR DESCRIPTION
Related issue: https://github.com/appium/appium_capybara/issues/44

Fix fatal error:
```
undefined method `custom' for #<Capybara::Selector::Definition:0x00007f99ef2c0f70> (NoMethodError)
```
when using the lib in conjunction with Capybara 3.19 and more

Breaking change, not compatible with Capybara 3.18 and less