### PR TITLE
Added swipe feature for android and ios

### DIFF
--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -79,6 +79,11 @@ module Appium::Capybara
     end
 
     # new
+    def swipe(start_x, start_y, offset_x=0, offset_y=0, duration=200)
+      Appium::TouchAction.new(browser).swipe(start_x: start_x, start_y: start_y, offset_x: offset_x, offset_y: offset_y, duration: duration).perform
+    end
+
+    # new
     # Use :landscape or :portrait
     def rotate(opts)
       browser.rotate opts

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -79,7 +79,13 @@ module Appium::Capybara
     end
 
     # new
-    def swipe(start_x, start_y, end_x=0, end_y=0, duration=200)
+    def swipe(opts)
+      start_x = opts.fetch :start_x, 0
+      start_y = opts.fetch :start_y, 0
+      end_x   = opts.fetch :end_x, 0
+      end_y   = opts.fetch :end_y, 0
+      duration = opts.fetch :duration, 200
+
       Appium::TouchAction.new(browser).swipe(start_x: start_x, start_y: start_y, end_x: end_x, end_y: end_y, duration: duration).perform
     end
 

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -79,8 +79,8 @@ module Appium::Capybara
     end
 
     # new
-    def swipe(start_x, start_y, offset_x=0, offset_y=0, duration=200)
-      Appium::TouchAction.new(browser).swipe(start_x: start_x, start_y: start_y, offset_x: offset_x, offset_y: offset_y, duration: duration).perform
+    def swipe(start_x, start_y, end_x=0, end_y=0, duration=200)
+      Appium::TouchAction.new(browser).swipe(start_x: start_x, start_y: start_y, end_x: end_x, end_y: end_y, duration: duration).perform
     end
 
     # new


### PR DESCRIPTION
# **How to use?**
### generic cmd for the bottom swipe
```
Capybara.current_session.driver.swipe(start_x: 75, start_y: 500)
```
### custom offsets, swipe speed
```
Capybara.current_session.driver.swipe(:start_x => 75, :start_y => 1500, :end_x => 0, :end_y => 0, :duration => 500)
Capybara.current_session.driver.swipe(start_x: 75, start_y: 500, end_x: 0, end_y: 0, duration: 500)
Capybara.current_session.driver.swipe(start_x: 75, start_y: 1500, duration: 500)
Capybara.current_session.driver.swipe(start_x: 75, start_y: 500, end_x: 0, end_y: 0)
```

**Note:** this swipe method is common for both Android and IOS; if needed we can move it another ruby file (just my thoughts)