### PR TITLE
chore: use w3c actions instead of mobile command

### DIFF
--- a/example/appium.txt
+++ b/example/appium.txt
@@ -1,6 +1,6 @@
 [caps]
 platformName = "ios"
 platformVersion = "15.0"
-deviceName ="iPhone Simulator"
-automationName = 'XCUITest'
+deviceName ="iPhone 11 Pro"
+automationName = "XCUITest"
 app = "./UICatalog.app.zip"

--- a/example/spec/ios_example_spec.rb
+++ b/example/spec/ios_example_spec.rb
@@ -33,5 +33,14 @@ describe 'UICatalog smoke test' do
     e.send_keys [:shift, :end]
 
     expect(e.text).to eq("")
+
+
+    Capybara.current_session.driver.appium_driver.back
+
+    sleep 1
+    capy_driver.scroll_down
+    sleep 1
+    capy_driver.scroll_up
+    Capybara.current_session.driver.appium_driver.find_element(:name, 'Text Fields').click
   end
 end

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -70,12 +70,30 @@ module Appium::Capybara
 
     # new
     def scroll_up
-      browser.execute_script('mobile: scroll', direction: 'up')
+      window = appium_driver.window_rect
+
+      action_builder = appium_driver.action
+      input = action_builder.pointer_inputs[0]
+      action_builder
+        .move_to_location(window.width / 2, window.height / 10)
+        .pointer_down(:left)
+        .move_to_location(window.width / 2, window.height * 8 / 10)
+        .release
+        .perform
     end
 
     # new
     def scroll_down
-      browser.execute_script('mobile: scroll', direction: 'down')
+      window = appium_driver.window_rect
+
+      action_builder = appium_driver.action
+      input = action_builder.pointer_inputs[0]
+      action_builder
+        .move_to_location(window.width / 2, window.height * 8 / 10)
+        .pointer_down(:left)
+        .move_to_location(window.width / 2, window.height / 10)
+        .release
+        .perform
     end
 
     # new


### PR DESCRIPTION
Tried to achieve https://github.com/appium/appium_capybara/issues/43 , but w3c actions depend on start/end points rather than current mobile command.

Then, I think scroll down/up in this module is probably not so good work well..