### PR TITLE
Fix Capybara::Node::Element.inspect

### DIFF
--- a/example/readme.md
+++ b/example/readme.md
@@ -3,7 +3,7 @@
 ```
 cd example
 bundle update
-rspec
+bundle exec rspec spec/ios_example_spec.rb
 ```
 
 # Use with pry

--- a/example/spec/home_page.rb
+++ b/example/spec/home_page.rb
@@ -3,5 +3,7 @@ module Pages
     # UIANavigationBar
     #   name: UICatalog
     elements :navigation_bar, :accessibility_id, 'UICatalog'
+
+    section :action_sheets_section, Sections::Sheets, :name, 'Action Sheets'
   end
 end

--- a/example/spec/ios_example_spec.rb
+++ b/example/spec/ios_example_spec.rb
@@ -5,6 +5,9 @@ describe 'UICatalog smoke test' do
     home_page = Pages::Home.new
     expect(home_page.navigation_bar.first).to be_truthy
 
+    # Use Capybara::Node::Element element
+    expect(home_page.action_sheets_section.has_buttons?).to be_falsey
+
     expect(Capybara.current_driver).to be :appium
 
     capy_driver = Capybara.current_session.driver

--- a/example/spec/sheets_section.rb
+++ b/example/spec/sheets_section.rb
@@ -1,0 +1,5 @@
+module Sections
+  class Sheets < SitePrism::Section
+    elements :buttons, :class, 'XCUIElementTypeButton'
+  end
+end

--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require_relative 'capybara_init'
 
+# sections
+require_relative 'sheets_section'
 # pages
 require_relative 'home_page'
 

--- a/lib/appium_capybara.rb
+++ b/lib/appium_capybara.rb
@@ -4,6 +4,7 @@ require_relative 'appium_capybara/driver/appium/driver'
 require_relative 'appium_capybara/driver/appium/node'
 
 require_relative 'appium_capybara/ext/base_ext'
+require_relative 'appium_capybara/ext/element_ext'
 require_relative 'appium_capybara/ext/selector_query_ext'
 require_relative 'appium_capybara/ext/selector_ext'
 

--- a/lib/appium_capybara/ext/element_ext.rb
+++ b/lib/appium_capybara/ext/element_ext.rb
@@ -1,0 +1,6 @@
+class Capybara::Node::Element
+  # Override
+  def inspect
+    %(#<Capybara::Node::Element name=#{@base.name}>)
+  end
+end


### PR DESCRIPTION
When I used Capybara::Node::Element(ex: `home_page.action_sheets_section.has_buttons?`) then I got a error below.
(some `caps` changes are for my simulator env.)

```
% bundle exec rspec spec/ios_example_spec.rb
{:caps=>{:platformName=>"ios", :platformVersion=>"14.4", :deviceName=>"iPhone 11", :automationName=>"XCUITest", :app=>"/Users/teppei-yamaguchi/work/appium_capybara/example/UICatalog.app.zip"}, :appium_lib=>{:server_url=>"http://localhost:4723/wd/hub"}, :global_driver=>false}
F

Failures:

  1) UICatalog smoke test should detect the nav bar and get some methods
     Failure/Error: expect(home_page.action_sheets_view.has_buttons?).to be_falsey
     Selenium::WebDriver::Error::UnknownMethodError:
       Method is not implemented
     # NotImplementedError: Method is not implemented
     #     at XCUITestDriver.execute (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/appium-xcuitest-driver/lib/commands/execute.js:38:11)
     #     at commandExecutor (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:335:9)
     #     at /Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/async-lock/lib/index.js:146:12
     #     at AsyncLock._promiseTry (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/async-lock/lib/index.js:280:31)
     #     at exec (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/async-lock/lib/index.js:145:9)
     #     at AsyncLock.acquire (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/async-lock/lib/index.js:162:3)
     #     at XCUITestDriver.executeCommand (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:348:39)
     #     at XCUITestDriver.executeCommand (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/appium-xcuitest-driver/lib/driver.js:779:24)
     #     at AppiumDriver.executeCommand (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/lib/appium.js:563:36)
     #     at runMicrotasks (<anonymous>)
     #     at processTicksAndRejections (internal/process/task_queues.js:93:5)
     #     at asyncHandler (/Users/teppei-yamaguchi/.anyenv/envs/nodenv/versions/14.7.0/lib/node_modules/appium/node_modules/appium-base-driver/lib/protocol/protocol.js:297:21)
     # ./spec/ios_example_spec.rb:9:in `block (2 levels) in <top (required)>'

Finished in 23.97 seconds (files took 1.79 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/ios_example_spec.rb:4 # UICatalog smoke test should detect the nav bar and get some methods
```

This error caused by Capybara::Node::Element.inspect. `Inspect` call `tag_name` and `path`.
But `tag_name` and `path` can't use in mobile. 

So I propose to change Capybara::Node::Element.inspect.

ref.)
class Capybara::Selenium::Node < Capybara::Driver::Node
```
      def inspect
        %(#<#{self.class} tag="#{tag_name}" path="#{path}">)
      rescue NotSupportedByDriverError
        %(#<#{self.class} tag="#{tag_name}">)
      end
```

class Appium::Capybara::Node < Capybara::Selenium::Node
```
    def inspect
      %(#<#{self.class} name="#{name}">)
    end
```
