### PR TITLE
fix: add webdrivererror handler instead of calling just name

### DIFF
--- a/lib/appium_capybara/ext/element_ext.rb
+++ b/lib/appium_capybara/ext/element_ext.rb
@@ -1,6 +1,10 @@
 class Capybara::Node::Element
   # Override
   def inspect
-    %(#<Capybara::Node::Element name=#{@base.name}>)
+    %(#<#{self.class} tag="#{tag_name}" path="#{path}">)
+  rescue ::Capybara::NotSupportedByDriverError, ::Selenium::WebDriver::Error::WebDriverError
+    # Native context does not have the 'path' strategy, so it could raise an exception.
+    # Then, the method can call tag_name instead.
+    %(#<#{self.class} tag="#{tag_name}">)
   end
 end


### PR DESCRIPTION
Instead of https://github.com/appium/appium_capybara/pull/62, maybe we could try the rescue clause when the primary method gets Selenium WebDriver exception.

the tag name is https://w3c.github.io/webdriver/#get-element-tag-name in the w3c spec while the "name" is Appium specific. So, when we consider the WebContext as well, it would be safe to keep the primary method in capybara. Instead, the rescue clause can have `::Selenium::WebDriver::Error::WebDriverError` as well so that the method can try out the `tag_name`. (in fact of the tag_name, Ruby client calls `/session/{session id}/element/{element id}/name` endpoint as the spec.

This case also get passed for the given scenario https://github.com/appium/appium_capybara/pull/62/files

cc @teyamagu 