### PR TITLE
Revert "fix: add webdrivererror handler instead of calling just name"

### DIFF
--- a/lib/appium_capybara/ext/element_ext.rb
+++ b/lib/appium_capybara/ext/element_ext.rb
@@ -1,10 +1,6 @@
 class Capybara::Node::Element
   # Override
   def inspect
-    %(#<#{self.class} tag="#{tag_name}" path="#{path}">)
-  rescue ::Capybara::NotSupportedByDriverError, ::Selenium::WebDriver::Error::WebDriverError
-    # Native context does not have the 'path' strategy, so it could raise an exception.
-    # Then, the method can call tag_name instead.
-    %(#<#{self.class} tag="#{tag_name}">)
+    %(#<Capybara::Node::Element name=#{@base.name}>)
   end
 end


### PR DESCRIPTION
Reverts appium/appium_capybara#66 to follow `Appium::Capybara::Node`
https://github.com/appium/appium_capybara/blob/master/lib/appium_capybara/driver/appium/node.rb#L27-L29