### PR TITLE
feat: bump the minimal appium_lib version and modify the upper

### DIFF
--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -24,7 +24,11 @@ jobs:
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
     - run: defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
-    - run: xcrun simctl list
+    - uses: futureware-tech/simulator-action@v3
+      with:
+        # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
+        model: ${{ env.DEVICE_NAME }}
+        os_version: ${{ env.PLATFORM_VERSION }}
     - name: Set up Appium env
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       PLATFORM_VERSION: '17.4'
       XCODE_VERSION: '15.3'
+      DEVICE_NAME: iPhone 15 Plus
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -12,10 +12,10 @@ permissions:
 jobs:
   test:
 
-    runs-on: macos-11
+    runs-on: macos-14
     env:
-      PLATFORM_VERSION: '15.2'
-      XCODE_VERSION: '13.2'
+      PLATFORM_VERSION: '17.4'
+      XCODE_VERSION: '15.3'
 
     steps:
     - uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
         check-latest: true
     - name: Install Appium XCUITest
       run: |
-        npm install -g appium@next
+        npm install -g appium
         appium driver install xcuitest
     - name: run Appium background
       run: |

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -32,8 +32,7 @@ jobs:
     - name: Set up Appium env
       uses: actions/setup-node@v3
       with:
-        node-version: 16
-        check-latest: true
+        node-version: 'lts/*'
     - name: Install Appium XCUITest
       run: |
         npm install -g appium
@@ -51,8 +50,8 @@ jobs:
         bundle install
         bundle exec rspec spec/ios_example_spec.rb
     - name: Upload appium.out
-      uses: actions/upload-artifact@v3.1.1
-      if: failure()
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4
       with:
         path: appium.out
 

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
+    - run: defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
     - run: xcrun simctl list
     - name: Set up Appium env
       uses: actions/setup-node@v3
@@ -36,10 +37,9 @@ jobs:
       run: |
         nohup appium --base-path=/wd/hub --log-timestamp --log-no-colors > appium.out 2>&1 &
     - name: Set up Ruby
-      uses: ruby/setup-ruby@0a29871fe2b0200a17a4497bae54fe5df0d973aa # v1.115.3
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1
-        bundler-cache: true
+        ruby-version: 3.2
     - name: Run example
       run: |
         cd example

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -1,6 +1,8 @@
 name: Run example
 
 on:
+  # Run by manual at this time
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:
@@ -13,6 +15,7 @@ jobs:
   test:
 
     runs-on: macos-14
+
     env:
       PLATFORM_VERSION: '17.4'
       XCODE_VERSION: '15.3'
@@ -20,19 +23,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: maxim-lobanov/setup-xcode@v1
+
+    - name: Install Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 'lts/*'
+
+    - name: Select Xcode
+      uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
     - run: defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
+
     - uses: futureware-tech/simulator-action@v3
       with:
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
         model: ${{ env.DEVICE_NAME }}
         os_version: ${{ env.PLATFORM_VERSION }}
-    - name: Set up Appium env
-      uses: actions/setup-node@v3
-      with:
-        node-version: 'lts/*'
+
     - name: Install Appium XCUITest
       run: |
         npm install -g appium
@@ -40,6 +48,7 @@ jobs:
     - name: run Appium background
       run: |
         nohup appium --base-path=/wd/hub --log-timestamp --log-no-colors > appium.out 2>&1 &
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -49,6 +58,7 @@ jobs:
         cd example
         bundle install
         bundle exec rspec spec/ios_example_spec.rb
+
     - name: Upload appium.out
       if: ${{ always() }}
       uses: actions/upload-artifact@v4

--- a/appium_capybara.gemspec
+++ b/appium_capybara.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/appium_capybara'
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'appium_lib', '~> 12.0.0'
+  s.add_runtime_dependency 'appium_lib', '>= 12.0.0'
   s.add_runtime_dependency 'capybara', '~> 3.36'
 
   s.add_development_dependency 'appium_thor', '~> 2.0'

--- a/appium_capybara.gemspec
+++ b/appium_capybara.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/appium/appium_capybara'
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'appium_lib', '>= 12.0.0'
+  s.add_runtime_dependency 'appium_lib', '>= 13.0.0'
   s.add_runtime_dependency 'capybara', '~> 3.36'
 
   s.add_development_dependency 'appium_thor', '~> 2.0'

--- a/example/spec/capybara_init.rb
+++ b/example/spec/capybara_init.rb
@@ -7,8 +7,8 @@ require 'site_prism'
 Capybara.register_driver(:appium) do |app|
   Appium::Capybara::Driver.new app, capabilities: {
       'platformName' => 'ios',
-      'platformVersion' => ENV['PLATFORM_VERSION'] || '16.0',
-      'appium:deviceName' => 'iPhone 12',
+      'platformVersion' => ENV['PLATFORM_VERSION'] || '17.4',
+      'appium:deviceName' => ENV['DEVICE_NAME'] || 'iPhone 15 Plus',
       'appium:automationName' => 'xcuitest',
       'appium:app' => File.expand_path('UICatalog.app.zip'),
       'appium:wdaLaunchTimeout' => 600000,

--- a/example/spec/capybara_init.rb
+++ b/example/spec/capybara_init.rb
@@ -11,7 +11,8 @@ Capybara.register_driver(:appium) do |app|
       'appium:deviceName' => ENV['DEVICE_NAME'] || 'iPhone 15 Plus',
       'appium:automationName' => 'xcuitest',
       'appium:app' => File.expand_path('UICatalog.app.zip'),
-      'appium:wdaLaunchTimeout' => 600000,
+      'appium:wdaLaunchTimeout' => 600_000,
+      'appium:simulatorStartupTimeout' => 600_000
     },
     appium_lib: { server_url: 'http://localhost:4723/wd/hub' },
     global_driver: false

--- a/example/spec/home_page.rb
+++ b/example/spec/home_page.rb
@@ -2,8 +2,8 @@ module Pages
   class Home < ::SitePrism::Page
     # UIANavigationBar
     #   name: UICatalog
-    elements :navigation_bar, :accessibility_id, 'UICatalog'
+    elements :navigation_bar, :accessibility_id, 'UIKitCatalog'
 
-    section :action_sheets_section, Sections::Sheets, :name, 'Action Sheets'
+    section :action_sheets_section, Sections::Sheets, :name, 'Alert Views'
   end
 end

--- a/example/spec/ios_example_spec.rb
+++ b/example/spec/ios_example_spec.rb
@@ -15,14 +15,14 @@ describe 'UICatalog smoke test' do
     # Call appium driver's methods
     Capybara.current_session.driver.appium_driver.find_element(:name, 'Buttons').click
     Capybara.current_session.driver.appium_driver.wait do
-      expect(capy_driver.find_custom(:class_name, 'XCUIElementTypeButton').size).to be 6
+      expect(capy_driver.find_custom(:class_name, 'XCUIElementTypeButton').size).to be 8
     end
 
     # Get Appium::Capybara::Node elements
     expect(capy_driver.find_custom(:name, 'X Button')[0].name).to eq('X Button')
 
     e = Capybara.current_session.find(:xpath, '//XCUIElementTypeNavigationBar')
-    expect(e.find(:class, 'XCUIElementTypeButton').text).to eq('UICatalog')
+    expect(e.find(:class, 'XCUIElementTypeButton').text).to eq('UIKitCatalog')
 
     Capybara.current_session.driver.appium_driver.back
 

--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -6,9 +6,9 @@ require_relative 'sheets_section'
 require_relative 'home_page'
 
 RSpec.configure do |config|
-  config.after(:each) { Capybara.current_session.driver.quit }
+  config.after(:each) { Capybara.current_session.driver&.quit }
 
   config.after do |result|
-    Capybara.current_session.driver.save_screenshot 'error.png' if result.exception
+    Capybara.current_session.driver&.save_screenshot 'error.png' if result.exception
   end
 end

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -91,9 +91,9 @@ module Appium::Capybara
       action_builder
         .move_to_location(start_x, start_y)
         .pointer_down(:left)
-        .pause(input, duration / 1000)
+        .pause(device: input, duration: duration / 1000)
         .move_to_location(end_x, end_y)
-        .pause(input, 1)
+        .pause(device: input, duration: 1)
         .release
         .perform
     end


### PR DESCRIPTION
Perhaps it would make sense to not restrict so much so that users can specify versions by following their local env. The min can be bumped when breaking changes in this lib occurs.


I'll do tests later