### PR TITLE
fix: replace reset with restart as similar behavior, fix inspect to respect super

### DIFF
--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
 
@@ -44,7 +48,7 @@ jobs:
         appium driver install xcuitest
     - name: run Appium background
       run: |
-        nohup appium --log-timestamp --log-no-colors > appium.out 2>&1 &
+        nohup appium --log-timestamp --log-no-colors > appium.log 2>&1 &
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -56,7 +60,7 @@ jobs:
         bundle exec rspec spec/ios_example_spec.rb
       working-directory: example
 
-    - name: Upload appium.out
+    - name: Upload appium.log
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: [ "master" ]
 
-permissions:
-  contents: read
-
 jobs:
   test:
 

--- a/.github/workflows/run_example.yml
+++ b/.github/workflows/run_example.yml
@@ -64,5 +64,5 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        path: appium.out
+        path: appium.log
 

--- a/example/spec/ios_example_spec.rb
+++ b/example/spec/ios_example_spec.rb
@@ -30,6 +30,7 @@ describe 'UICatalog smoke test' do
     Capybara.current_session.driver.appium_driver.find_element(:name, 'Text Fields').click
 
     e = capy_driver.find_custom(:predicate, 'value == "Placeholder text"').first
+    e.inspect
     e.send_keys [:shift, :end]
 
     e = Capybara.current_session.find(:xpath, '//XCUIElementTypeTextField[@value=""]')

--- a/lib/appium_capybara/driver/appium/driver.rb
+++ b/lib/appium_capybara/driver/appium/driver.rb
@@ -46,9 +46,8 @@ module Appium::Capybara
 
     # override
     def reset!
-      # invoking the browser method after the browser has closed will cause it to relaunch
-      # use @appium_driver to avoid the relaunch.
-      @appium_driver.reset if @appium_driver
+      # Re-create a new session.
+      @appium_driver&.restart
     end
 
     # @deprecated This method is being removed

--- a/lib/appium_capybara/ext/element_ext.rb
+++ b/lib/appium_capybara/ext/element_ext.rb
@@ -1,6 +1,8 @@
 class Capybara::Node::Element
   # Override
   def inspect
+    return super unless @base.respond_to? :name
+    # appium specific
     %(#<Capybara::Node::Element name=#{@base.name}>)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/appium/appium_capybara/issues/76 https://github.com/appium/appium_capybara/issues/77

`reset` endpoint was removed from Appium since it was equivalent to the session restart (end the session -> create a new one). So this `reset` also can do the same thing. All capabilities etc are the same.